### PR TITLE
Improve log output

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,54 +9,78 @@ require('./lib/extensions');
 module.exports = function (di, directory) {
     var helper = require('./lib/di')(di, directory || __dirname);
 
+    var injectables = _.flattenDeep(
+        [
+            // NPM Packages
+            helper.simpleWrapper(_, '_'),
+            helper.requireWrapper('bluebird', 'Promise'),
+            helper.requireWrapper('rx', 'Rx'),
+            helper.requireWrapper('nconf'),
+            helper.requireWrapper('waterline', 'Waterline'),
+            helper.requireWrapper('waterline-criteria', 'WaterlineCriteria'),
+            helper.requireWrapper('sails-mongo', 'MongoAdapter'),
+            helper.requireWrapper('amqp', 'amqp'),
+            helper.requireWrapper('domain', 'domain'),
+            helper.requireWrapper('node-uuid', 'uuid'),
+            helper.requireWrapper('stack-trace', 'stack-trace'),
+            helper.requireWrapper('colors/safe', 'colors'),
+            helper.requireWrapper('prettyjson', 'prettyjson'),
+            helper.requireWrapper('lru-cache', 'lru-cache'),
+            helper.requireWrapper('node-statsd', 'node-statsd'),
+            helper.requireWrapper('validate.js', 'validate'),
+            helper.requireWrapper('validator', 'validator'),
+            helper.requireWrapper('assert-plus', 'assert-plus'),
+            helper.requireWrapper('ejs', 'ejs'),
+            helper.requireWrapper('hogan.js', 'Hogan'),
+            helper.requireWrapper('fs', 'fs'),
+            helper.requireWrapper('path', 'path'),
+            helper.requireWrapper('child_process', 'child_process'),
+            helper.requireWrapper('anchor', 'anchor'),
+            helper.requireWrapper('jsonschema', 'jsonschema'),
+            helper.simpleWrapper(console, 'console'),
+            helper.simpleWrapper(require('eventemitter2').EventEmitter2, 'EventEmitter'),
+            helper.requireWrapper('shortid', 'shortid'),
+            helper.requireWrapper('crypto', 'crypto'),
+            helper.requireWrapper('apache-crypt', 'apache-crypt'),
+            helper.requireWrapper('util', 'util'),
+            helper.requireWrapper('pluralize', 'pluralize'),
+            helper.requireWrapper('blocked', 'blocked'),
+            helper.requireWrapper('always-tail', 'Tail'),
+            helper.requireWrapper('flat', 'flat'),
+
+            // Glob Requirables
+            helper.requireGlob(__dirname + '/lib/common/*.js'),
+            helper.requireGlob(__dirname + '/lib/models/*.js'),
+            helper.requireGlob(__dirname + '/lib/protocol/*.js'),
+            helper.requireGlob(__dirname + '/lib/serializables/*.js'),
+            helper.requireGlob(__dirname + '/lib/services/*.js')
+        ]
+    );
+
+    var injector = new di.Injector(injectables);
+    handleConfig(injector);
+
     return {
         helper: helper,
-        injectables: _.flattenDeep(
-            [
-                // NPM Packages
-                helper.simpleWrapper(_, '_'),
-                helper.requireWrapper('bluebird', 'Promise'),
-                helper.requireWrapper('rx', 'Rx'),
-                helper.requireWrapper('nconf'),
-                helper.requireWrapper('waterline', 'Waterline'),
-                helper.requireWrapper('waterline-criteria', 'WaterlineCriteria'),
-                helper.requireWrapper('sails-mongo', 'MongoAdapter'),
-                helper.requireWrapper('amqp', 'amqp'),
-                helper.requireWrapper('domain', 'domain'),
-                helper.requireWrapper('node-uuid', 'uuid'),
-                helper.requireWrapper('stack-trace', 'stack-trace'),
-                helper.requireWrapper('colors/safe', 'colors'),
-                helper.requireWrapper('prettyjson', 'prettyjson'),
-                helper.requireWrapper('lru-cache', 'lru-cache'),
-                helper.requireWrapper('node-statsd', 'node-statsd'),
-                helper.requireWrapper('validate.js', 'validate'),
-                helper.requireWrapper('validator', 'validator'),
-                helper.requireWrapper('assert-plus', 'assert-plus'),
-                helper.requireWrapper('ejs', 'ejs'),
-                helper.requireWrapper('hogan.js', 'Hogan'),
-                helper.requireWrapper('fs', 'fs'),
-                helper.requireWrapper('path', 'path'),
-                helper.requireWrapper('child_process', 'child_process'),
-                helper.requireWrapper('anchor', 'anchor'),
-                helper.requireWrapper('jsonschema', 'jsonschema'),
-                helper.simpleWrapper(console, 'console'),
-                helper.simpleWrapper(require('eventemitter2').EventEmitter2, 'EventEmitter'),
-                helper.requireWrapper('shortid', 'shortid'),
-                helper.requireWrapper('crypto', 'crypto'),
-                helper.requireWrapper('apache-crypt', 'apache-crypt'),
-                helper.requireWrapper('util', 'util'),
-                helper.requireWrapper('pluralize', 'pluralize'),
-                helper.requireWrapper('blocked', 'blocked'),
-                helper.requireWrapper('always-tail', 'Tail'),
-                helper.requireWrapper('flat', 'flat'),
-
-                // Glob Requirables
-                helper.requireGlob(__dirname + '/lib/common/*.js'),
-                helper.requireGlob(__dirname + '/lib/models/*.js'),
-                helper.requireGlob(__dirname + '/lib/protocol/*.js'),
-                helper.requireGlob(__dirname + '/lib/serializables/*.js'),
-                helper.requireGlob(__dirname + '/lib/services/*.js')
-            ]
-        )
+        injectables: injectables
     };
 };
+
+/**
+ * Handle the configuration value
+ *
+ * TODO: This is not good place to put such configuration handle code especially when we have
+ * lot of configuration need to be handled in future. So we need to move this to a better place.
+ *
+ * @param {Object} injector - DI injector instance used to retrieve dependancy modules
+ */
+function handleConfig(injector) {
+    var configuration = injector.get('Services.Configuration');
+
+    // Handle Log Color
+    var LogEvent = injector.get('LogEvent');
+    var colorEnable = configuration.get('color', false, true) ||
+                      configuration.get('logColorEnable', false, true);
+    LogEvent.setColorEnable(colorEnable);
+}
+

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -26,7 +26,7 @@ function constantsFactory (path) {
               error: 'red',
               warning: 'yellow',
               info: 'green',
-              debug: 'blue',
+              debug: 'cyan',
             },
             Levels: {
                 critical: 5,

--- a/lib/serializables/log-event.js
+++ b/lib/serializables/log-event.js
@@ -32,7 +32,10 @@ function LogEventFactory (
     pretty,
     console
 ) {
-    colors.setTheme(Constants.Logging.Colors);
+    //default turn off the colorful output to achieve tidy and clean log file.
+    LogEvent.colorEnable = false;
+
+    colors.setTheme(Constants.Logging.Colors); //setTheme will not impact color enable or not
 
     function LogEvent(defaults) {
         Serializable.call(this, LogEvent.schema, defaults);
@@ -80,9 +83,8 @@ function LogEventFactory (
         var statement = [];
 
         this.context = LogEvent.redact(this.context);
-
-        statement.push(this.level[0].toUpperCase());
-        statement.push(this.timestamp);
+        statement.push('[%s]'.format(this.level));
+        statement.push('[%s]'.format(this.timestamp));
         statement.push('[%s]'.format(this.name));
         statement.push('[%s]'.format(this.module));
         statement.push('[%s]'.format(
@@ -93,13 +95,16 @@ function LogEventFactory (
         var output = statement.join(' ');
 
         console.log(colors[this.level](output));
-        console.log(' -> ' + this.caller);
+        console.log(colors[this.level](' -> ' + this.caller));
 
         if (_.keys(this.context).length > 0) {
             console.log(
                 pretty.render(
                     this.context,
-                    { noColor: false }
+                    {
+                        noColor: !LogEvent.colorEnable,
+                        numberColor: 'cyan'
+                    }
                 )
             );
         }
@@ -117,6 +122,15 @@ function LogEventFactory (
             }).then(function (object) {
                 return object.validate();
             });
+    };
+
+    /**
+     * Set enabled or disabled for colorful log
+     * @param {boolean} enable - true to enable colorful log; false to disable
+     */
+    LogEvent.setColorEnable = function(enable) {
+        LogEvent.colorEnable = (enable ? true : false);
+        colors.enabled = LogEvent.colorEnable;
     };
 
     LogEvent.sanitize = function(context) {

--- a/lib/services/configuration.js
+++ b/lib/services/configuration.js
@@ -58,10 +58,11 @@ function configurationServiceFactory(
         return this;
     };
 
-    ConfigurationService.prototype.get = function get(key, defaults) {
+    ConfigurationService.prototype.get = function get(key, defaults, suppressWarning) {
         assert.string(key, 'key');
+        suppressWarning = (suppressWarning || false);
 
-        if (!this.started) {
+        if (!this.started && !suppressWarning) {
             logger.deprecate(
                 'Attempting to access %s - prior to configuration service being started'.format(
                     key), 3
@@ -71,10 +72,12 @@ function configurationServiceFactory(
         var value = nconf.get(key);
 
         if (value === undefined) {
-            logger.info('Configuration value is undefined, using default (%s => %s).'.format(
-                key,
-                defaults
-            ));
+            if (!suppressWarning) {
+                logger.info('Configuration value is undefined, using default (%s => %s).'.format(
+                    key,
+                    defaults
+                ));
+            }
 
             return defaults;
         }

--- a/spec/lib/serializables/log-event-spec.js
+++ b/spec/lib/serializables/log-event-spec.js
@@ -5,11 +5,13 @@
 
 describe('LogEvent', function () {
     var LogEvent;
+    var lookupService;
 
     helper.before();
 
     before(function () {
         LogEvent = helper.injector.get('LogEvent');
+        lookupService = helper.injector.get('Services.Lookup');
     });
 
     helper.after();
@@ -67,6 +69,121 @@ describe('LogEvent', function () {
                 LogEvent.redact(target);
 
                 target.should.deep.equal({ password: 'bar' });
+            });
+        });
+
+        describe('getUniqueId', function() {
+            var sandbox;
+            before(function() {
+                sandbox = sinon.sandbox.create();
+            });
+
+            afterEach(function() {
+                sandbox.restore();
+            });
+
+            it('should return undefined for empty context', function() {
+                return LogEvent.getUniqueId().should.become(undefined);
+            });
+
+            it('should favor context.id', function() {
+                return LogEvent.getUniqueId({
+                    id: 'testid',
+                    macaddress: 'testmac',
+                    ip: 'testip'
+                }).should.become('testid');
+            });
+
+            it('should favor macaddress if id not exists', function() {
+                sandbox.stub(lookupService, 'macAddressToNodeId')
+                    .withArgs('testmac').resolves('aa:bb:cc:dd:ee:ff');
+                return LogEvent.getUniqueId({
+                    macaddress: 'testmac',
+                    ip: 'testip'
+                }).should.become('aa:bb:cc:dd:ee:ff');
+            });
+
+            it('should reject if lookup macaddress fails', function() {
+                sandbox.stub(lookupService, 'macAddressToNodeId')
+                    .withArgs('testmac').rejects();
+                return LogEvent.getUniqueId({
+                    macaddress: 'testmac',
+                    ip: 'testip'
+                }).should.be.rejected;
+            });
+
+            it('should favor ip if both id & macaddress not exists', function() {
+                sandbox.stub(lookupService, 'ipAddressToNodeId')
+                    .withArgs('testip').resolves('192.168.100.1');
+                return LogEvent.getUniqueId({
+                    ip: 'testip',
+                    other: 'testother'
+                }).should.become('192.168.100.1');
+            });
+
+            it('should reject if lookup ip fails', function() {
+                sandbox.stub(lookupService, 'ipAddressToNodeId')
+                    .withArgs('testip').rejects();
+                return LogEvent.getUniqueId({
+                    ip: 'testip',
+                    other: 'testother'
+                }).should.be.rejected;
+            });
+
+            it('should return undefined if id/macaddress/ip all not exist', function() {
+                return LogEvent.getUniqueId({
+                    'test': 'testmessage',
+                    'abc': 'testabc'
+                }).should.become(undefined);
+            });
+        });
+
+        describe('getSubject', function() {
+            var sandbox;
+            before(function() {
+                sandbox = sinon.sandbox.create();
+            });
+
+            afterEach(function() {
+                sandbox.restore();
+            });
+
+            it('should return subject', function() {
+                sandbox.stub(LogEvent, 'getUniqueId')
+                    .withArgs('testContext').resolves('testSubject');
+                return LogEvent.getSubject('testContext').should.become('testSubject');
+            });
+
+            it('should return default subject if getUniqueId returns empty', function() {
+                sandbox.stub(LogEvent, 'getUniqueId')
+                    .withArgs('testContext').resolves();
+                return LogEvent.getSubject('testContext').should.become('Server');
+            });
+
+            it('should return default subject if getUniqueId rejects', function() {
+                sandbox.stub(LogEvent, 'getUniqueId')
+                    .withArgs('testContext').rejects();
+                return LogEvent.getSubject('testContext').should.become('Server');
+            });
+        });
+
+        describe('setColorEnable', function() {
+            var colors;
+
+            before(function() {
+                colors = helper.injector.get('colors');
+            });
+
+            it('should enable colors', function() {
+                LogEvent.setColorEnable(true);
+                expect(colors.enabled).to.be.true;
+                expect(LogEvent.colorEnable).to.be.true;
+            });
+
+            it('should disable colors', function() {
+                LogEvent.setColorEnable(false);
+                expect(colors.enabled).to.be.false;
+                expect(LogEvent.colorEnable).to.be.false;
             });
         });
     });


### PR DESCRIPTION
- default turn off colorful output, user can turn on the colorful output by configuration: --color or --logColorEnable
- print full log level name
- print caller uses the same color of corresponding log level
- change the color for 'debug' level to cyan
- improve LogEvent unittest coverage
